### PR TITLE
Fix warning: Function 'is_rest_request' has been deprecated

### DIFF
--- a/src/integrations/index-now-ping.php
+++ b/src/integrations/index-now-ping.php
@@ -111,7 +111,7 @@ class Index_Now_Ping implements Integration_Interface {
 		}
 
 		// The block editor saves published posts twice, we want to ping only on the first request.
-		if ( $new_status === 'publish' && $this->request_helper->is_rest_request() ) {
+		if ( $new_status === 'publish' && wp_is_serving_rest_request() ) {
 			return;
 		}
 


### PR DESCRIPTION
Deprecated: Function Yoast\WP\SEO\Helpers\Request_Helper::is_rest_request has been deprecated.

Use `wp_is_serving_rest_request` for instead

Environment: WordPress Cron